### PR TITLE
A kind of already running

### DIFF
--- a/lib/ringleader/process.rb
+++ b/lib/ringleader/process.rb
@@ -131,6 +131,11 @@ module Ringleader
       @starting = false
       @running = false
       false
+    rescue Errno::EADDRINUSE
+      @starting = false
+      @running = true
+      warn "#{config.name} already running on port #{config.app_port}"
+      return true
     ensure
       unless @running
         warn "could not start `#{config.command}`"


### PR DESCRIPTION
If you start an app after the Ringleader you will see Ringleader trying to start the app each request and an error. Fixing it.
