### PR TITLE
Fix sys-proctable issue and bump version

### DIFF
--- a/lib/ringleader/version.rb
+++ b/lib/ringleader/version.rb
@@ -1,3 +1,3 @@
 module Ringleader
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/ringleader.gemspec
+++ b/ringleader.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "trollop", "~> 1.16.2"
   gem.add_dependency "rainbow", "~> 1.1.4"
   gem.add_dependency "color", "~> 1.4.1"
-  gem.add_dependency "sys-proctable", "~> 0.9.2"
+  gem.add_dependency "sys-proctable", "<= 0.9.1"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.11.0"


### PR DESCRIPTION
Change sys-proctable to <= 0.9.1 because 0.9.2 is not working well on some OS X versions and bump version to release a fixed version.

More details in: https://github.com/djberg96/sys-proctable/issues/26
