### PR TITLE
Verbose wasn't working as expected.

### DIFF
--- a/lib/ringleader/cli.rb
+++ b/lib/ringleader/cli.rb
@@ -15,7 +15,7 @@ module Ringleader
       die "must provide a filename" if argv.empty?
       die "could not find config file #{argv.first}" unless File.exist?(argv.first)
 
-      if opts.verbose?
+      if opts.verbose
         Celluloid.logger.level = ::Logger::DEBUG
       end
 


### PR DESCRIPTION
`opts.verbose?` always returns nil.

``` ruby
1.9.3 (#<Ringleader::CLI:0x007fcc8b439900>)> opts.verbose
true
1.9.3 (#<Ringleader::CLI:0x007fcc8b439900>)> opts.verbose?
nil
```
